### PR TITLE
feat: auto-update README with latest articles from RSS feed

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,39 @@
+name: Update README with latest articles
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run update script
+        run: node scripts/update-readme.js
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet README.md || (
+            git add README.md &&
+            git commit -m "chore: update latest articles" &&
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          )
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@
 <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=3178C6&color=282C34&style=flat&logoWidth=30" /></a>
 
 > Full-stack Developer from Vietnam · Building web apps with Vue/Nuxt & Laravel
+
+## Latest Articles
+
+<!-- ARTICLES-LIST:START -->
+<!-- ARTICLES-LIST:END -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "thaolaptrinh",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thaolaptrinh",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.8"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "thaolaptrinh",
+  "version": "1.0.0",
+  "description": "GitHub profile for thaolaptrinh",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "fast-xml-parser": "^5.5.8"
+  }
+}

--- a/scripts/update-readme.js
+++ b/scripts/update-readme.js
@@ -1,0 +1,94 @@
+import { XMLParser } from "fast-xml-parser";
+import { readFileSync, writeFileSync } from "node:fs";
+import { get } from "node:https";
+
+const RSS_URL = "https://thaolaptrinh.com/feed.xml";
+const README_PATH = new URL("../README.md", import.meta.url).pathname;
+const START_MARKER = "<!-- ARTICLES-LIST:START -->";
+const END_MARKER = "<!-- ARTICLES-LIST:END -->";
+
+function fetchUrl(url) {
+  return new Promise((resolve, reject) => {
+    get(url, (res) => {
+      if (
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        fetchUrl(res.headers.location).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+        res.resume();
+        return;
+      }
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      res.on("error", reject);
+    }).on("error", reject);
+  });
+}
+
+function formatDate(pubDate) {
+  const date = new Date(pubDate);
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const yyyy = date.getUTCFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}
+
+async function main() {
+  console.log("Fetching RSS feed...");
+  const xml = await fetchUrl(RSS_URL);
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    cdataPropName: "__cdata",
+  });
+  const result = parser.parse(xml);
+
+  const raw = result.rss?.channel?.item;
+  if (!raw) {
+    console.log("No items found in feed.");
+    return;
+  }
+  const items = [raw].flat();
+
+  const lines = items.map((item) => {
+    const title = item.title?.__cdata ?? item.title ?? "(no title)";
+    const link = item.link ?? "";
+    const date = item.pubDate ? formatDate(item.pubDate) : "N/A";
+    return `- [${title.trim()}](${link}) — ${date}`;
+  });
+
+  const block = `${START_MARKER}\n${lines.join("\n")}\n${END_MARKER}`;
+
+  const readme = readFileSync(README_PATH, "utf8");
+  const startIdx = readme.indexOf(START_MARKER);
+  const endIdx = readme.indexOf(END_MARKER);
+
+  if (startIdx === -1 || endIdx === -1) {
+    console.error("Markers not found in README.md");
+    process.exit(1);
+  }
+
+  const updated =
+    readme.slice(0, startIdx) +
+    block +
+    readme.slice(endIdx + END_MARKER.length);
+
+  if (updated === readme) {
+    console.log("No changes detected.");
+    return;
+  }
+
+  writeFileSync(README_PATH, updated, "utf8");
+  console.log(`Updated README.md with ${lines.length} article(s).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/update-readme.js` to fetch RSS feed, parse XML, and update README.md
- Add `.github/workflows/update-readme.yml` scheduled daily at 00:00 UTC with `workflow_dispatch` support
- Add `## Latest Articles` section with markers in README.md

## How it works

1. GitHub Action triggers daily at 00:00 UTC
2. Script fetches `https://thaolaptrinh.com/feed.xml`
3. Parses articles and replaces content between `<!-- ARTICLES-LIST:START -->` and `<!-- ARTICLES-LIST:END -->`
4. Commits and pushes only if README.md changed

## Test plan

- [ ] Run `node scripts/update-readme.js` locally and verify README.md is updated correctly
- [ ] Trigger workflow manually via `workflow_dispatch` on GitHub Actions
- [ ] Verify commit `chore: update latest articles` is created automatically